### PR TITLE
Fix "Usage" command syntax: "nested_scaffold", not "scaffold"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,7 +23,7 @@ Then bundle:
 
 == Usage
 
-  % rails generate scaffold PARENT_NAME/NAME [field:type field:type] [options]
+  % rails generate nested_scaffold PARENT_NAME/NAME [field:type field:type] [options]
 
 (Expects PARENT model to exist in advance)
 


### PR DESCRIPTION
You have a typo in your Readme that caused me some confusion :)
Running "generate scaffold post/comment" would call the standard scaffold feature, creating a comment model within a post module.
