### PR TITLE
Small fix for scaffold generator

### DIFF
--- a/lib/generators/scaffold_controller/templates/controller.rb
+++ b/lib/generators/scaffold_controller/templates/controller.rb
@@ -83,7 +83,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_name %>.destroy
 
     respond_to do |format|
-      format.html { redirect_to <%= nested_parent_name %>_<%= index_helper %>_url(<%= nested_parent_name %>) }
+      format.html { redirect_to <%= nested_parent_name %>_<%= index_helper %>_url(@<%= nested_parent_name %>) }
       format.json { head :ok }
     end
   end


### PR DESCRIPTION
One character template fix: redirect in `destroy` action should reference instance variable instead of non-existent local variable.
