### PR TITLE
add form_with for Rails >= 5.1 compliance

### DIFF
--- a/lib/generators/erb/templates/_form.html.erb
+++ b/lib/generators/erb/templates/_form.html.erb
@@ -1,4 +1,8 @@
+<% if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 1 -%>
+<%%= form_with(model: [@<%= singular_table_name %>.<%= nested_parent_name %>, @<%= singular_table_name %>]) do |f| %>
+<% else -%>
 <%%= form_for([@<%= singular_table_name %>.<%= nested_parent_name %>, @<%= singular_table_name %>]) do |f| %>
+<% end -%>
   <%% if @<%= singular_table_name %>.errors.any? %>
     <div id="error_explanation">
       <h2><%%= pluralize(@<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>

--- a/lib/generators/haml/templates/_form.html.haml
+++ b/lib/generators/haml/templates/_form.html.haml
@@ -1,3 +1,6 @@
+-if Rails::VERSION::MAJOR >= 5 && Rails::VERSION::MINOR >= 1
+= form_with model: [@<%= singular_table_name %>.<%= nested_parent_name %>, @<%= singular_table_name %>] do |f|
+-else
 = form_for [@<%= singular_table_name %>.<%= nested_parent_name %>, @<%= singular_table_name %>] do |f|
   -if @<%= singular_table_name %>.errors.any?
     #error_explanation


### PR DESCRIPTION
The goal of this pull request is to future proof _form.html.erb and _form.html.haml regarding the future deprecation of `form_for`. Please reference [Rails Pull Request](https://github.com/rails/rails/issues/25197) and [Rails 5.1 Release Notes](http://edgeguides.rubyonrails.org/5_1_release_notes.html#unification-of-form-for-and-form-tag-into-form-with)